### PR TITLE
feat: 토글 카드 컴포넌트 구현

### DIFF
--- a/src/app/(with-nav)/test/page.tsx
+++ b/src/app/(with-nav)/test/page.tsx
@@ -4,6 +4,8 @@ import ContentWrapper from '@/components/layout/ContentWrapper';
 import Header from '@/components/layout/Header';
 import AlertModal from '@/components/modal/AlertModal';
 import ConfirmModal from '@/components/modal/ConfirmModal';
+import NoticeToggleCard from '@/components/ui/NoticeToggleCard';
+import PlanToggleCard from '@/components/ui/PlanToggleCard';
 import ScrollButtonGroup from '@/components/ui/ScrollButtonGroup';
 import Toggle from '@/components/ui/Toggle';
 import { useState } from 'react';
@@ -114,6 +116,18 @@ export default function Page() {
         >
           얼럿 모달 열기
         </button>
+
+        <PlanToggleCard title="단계별 계획 1주차">
+          <div>1일차 : 단어 10개 암기</div>
+          <div>2일차 : 문법 공부</div>
+          <div>3일차 : 문제 10개 풀기</div>
+        </PlanToggleCard>
+
+        <NoticeToggleCard
+          title="Nutree 서비스 오픈 안내"
+          content="안녕하세요, 다람쥐와 함께하는 목표 관리 서비스 Nutree가 드디어 오픈했습니다. 작은 도토리(목표)에서 시작해 큰 나무(성취)를 키워가는 여정을 지금부터 함께할 수 있어요. 앞으로 꾸준한 업데이트와 개선으로 더 나은 서비스를 제공하겠습니다. 많은 관심과 사랑 부탁드립니다!"
+          date="2025.09.19"
+        />
 
         {/* 모달 영역 */}
         <ConfirmModal

--- a/src/components/layout/ContentWrapper.tsx
+++ b/src/components/layout/ContentWrapper.tsx
@@ -1,13 +1,29 @@
 import { tw } from '@/lib/tw';
 
+type PaddingSize = 'sm' | 'md' | 'lg' | 'xl';
+
 type Props = {
   withNav?: boolean;
   children: React.ReactNode;
+  padding?: PaddingSize;
 };
 
-export default function ContentWrapper({ withNav, children }: Props) {
+export default function ContentWrapper({
+  withNav,
+  children,
+  padding = 'sm'
+}: Props) {
+  const paddingClass = {
+    sm: 'p-4', // 16px
+    md: 'p-5', // 20px
+    lg: 'p-6', // 24px
+    xl: 'p-7' // 28px
+  }[padding];
+
   return (
-    <main className={tw('flex-1 p-4', withNav && 'pb-[calc(65px+16px)]')}>
+    <main
+      className={tw('flex-1', paddingClass, withNav && 'pb-[calc(65px+16px)]')}
+    >
       {children}
     </main>
   );

--- a/src/components/ui/NoticeToggleCard.tsx
+++ b/src/components/ui/NoticeToggleCard.tsx
@@ -1,0 +1,60 @@
+'use client';
+
+import { useState } from 'react';
+import { motion } from 'framer-motion';
+import { MdKeyboardArrowDown } from 'react-icons/md';
+import ToggleContent from './ToggleContent';
+
+interface Props {
+  title: string;
+  content: string;
+  date: string;
+  defaultOpen?: boolean;
+}
+
+export default function NoticeToggleCard({
+  title,
+  content,
+  date,
+  defaultOpen = false
+}: Props) {
+  const [open, setOpen] = useState(defaultOpen);
+
+  return (
+    <motion.div
+      initial={false}
+      className="rounded-xl overflow-hidden shadow-sm hover:shadow-md transition-shadow"
+    >
+      {/* 헤더 영역 */}
+      <button
+        onClick={() => setOpen(prev => !prev)}
+        className={`w-full p-4 text-left flex justify-between items-center transition-colors cursor-pointer
+          ${
+            open
+              ? 'bg-button-selected text-bg-main'
+              : 'bg-bg-card-default text-basic-black'
+          }
+        `}
+      >
+        <span className="text-baase font-semibold">{title}</span>
+        <motion.div
+          animate={{ rotate: open ? 180 : 0 }}
+          transition={{ duration: 0.2 }}
+          className="w-6 h-6"
+        >
+          <MdKeyboardArrowDown size={24} />
+        </motion.div>
+      </button>
+
+      {/* 토글 영역 */}
+      <ToggleContent open={open} className="bg-bg-card-default">
+        <div className="p-5">
+          <div className="text-basic-black text-sm mb-4">{content}</div>
+          <span className="block text-right text-sm font-semibold text-gray-04">
+            {date}
+          </span>
+        </div>
+      </ToggleContent>
+    </motion.div>
+  );
+}

--- a/src/components/ui/PlanToggleCard.tsx
+++ b/src/components/ui/PlanToggleCard.tsx
@@ -37,8 +37,7 @@ export default function PlanToggleCard({
 
       {/* 토글 영역 */}
       <ToggleContent open={open}>
-        <div className="pb-5">{children}</div>
-        <div className="border-b border-[#A1A1A2]" />
+        <div className="pb-3">{children}</div>
       </ToggleContent>
     </div>
   );

--- a/src/components/ui/PlanToggleCard.tsx
+++ b/src/components/ui/PlanToggleCard.tsx
@@ -1,0 +1,45 @@
+'use client';
+
+import { useState } from 'react';
+import { motion } from 'framer-motion';
+import { MdKeyboardArrowDown } from 'react-icons/md';
+import ToggleContent from './ToggleContent';
+
+interface Props {
+  title: string;
+  children: React.ReactNode;
+  defaultOpen?: boolean;
+}
+
+export default function PlanToggleCard({
+  title,
+  children,
+  defaultOpen = false
+}: Props) {
+  const [open, setOpen] = useState(defaultOpen);
+
+  return (
+    <div className="w-full">
+      {/* 헤더 영역 */}
+      <button
+        onClick={() => setOpen(prev => !prev)}
+        className="w-full flex items-center justify-between py-3 cursor-pointer"
+      >
+        <span className="text-lg font-bold text-gray-09">{title}</span>
+        <motion.div
+          animate={{ rotate: open ? 180 : 0 }}
+          transition={{ duration: 0.2 }}
+          className="w-6 h-6 text-gray-09"
+        >
+          <MdKeyboardArrowDown size={24} />
+        </motion.div>
+      </button>
+
+      {/* 토글 영역 */}
+      <ToggleContent open={open}>
+        <div className="pb-5">{children}</div>
+        <div className="border-b border-[#A1A1A2]" />
+      </ToggleContent>
+    </div>
+  );
+}

--- a/src/components/ui/ScrollButtonGroup.tsx
+++ b/src/components/ui/ScrollButtonGroup.tsx
@@ -9,8 +9,8 @@ interface Props {
 
 export default function ScrollButtonGroup({withNav = false}: Props){
   return (
-    <div className={tw('sticky flex justify-end', withNav ? 'bottom-[calc(65px+16px)]':'bottom-4')}>
-      <div className='flex flex-col gap-2'>
+    <div className={tw('sticky flex justify-end pointer-events-none', withNav ? 'bottom-[calc(65px+16px)]':'bottom-4')}>
+      <div className='flex flex-col gap-2 pointer-events-auto'>
         <ScrollButton direction="top" />
         <ScrollButton direction="bottom" />
       </div>

--- a/src/components/ui/ToggleContent.tsx
+++ b/src/components/ui/ToggleContent.tsx
@@ -1,0 +1,32 @@
+'use client';
+
+import { tw } from '@/lib/tw';
+import { AnimatePresence, motion } from 'framer-motion';
+
+interface ToggleContentProps {
+  open: boolean;
+  children: React.ReactNode;
+  className?: string;
+}
+
+export default function ToggleContent({
+  open,
+  children,
+  className
+}: ToggleContentProps) {
+  return (
+    <AnimatePresence initial={false}>
+      {open && (
+        <motion.div
+          initial={{ height: 0, opacity: 0 }}
+          animate={{ height: 'auto', opacity: 1 }}
+          exit={{ height: 0, opacity: 0 }}
+          transition={{ duration: 0.2 }}
+          className={tw('overflow-hidden', className)}
+        >
+          {children}
+        </motion.div>
+      )}
+    </AnimatePresence>
+  );
+}


### PR DESCRIPTION
## 🛰️ Issue Number
<!-- ex) #이슈번호, #이슈번호 -->
[B8-56](https://moon472907.atlassian.net/browse/B8-56)

## 🪐 작업 내용
<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능) -->
<img width="400" alt="image" src="https://github.com/user-attachments/assets/c57732bb-ac23-4217-9951-9086852055ca" />

## 📚 Reference
<!-- 참고한 자료나 관련 문서, 링크를 간략히 적어주세요 -->

## ✅ Check List
- [x] `ContentWrapper.tsx` 패딩값 prop으로 받게 추가
- [x] 공지사항 토글 카드 구현
- [x] 계획 토글 카드 구현
- [x] 스크롤 버튼 동일선상 영역 클릭 안되는 문제 수정

## ℹ️ Note
<!-- 추가적으로 공유할 내용이나 주의사항을 간략히 설명해주세요 -->

``` tsx
<ContentWrapper padding='md'> // 기본값 'sm'
```
`ContentWrapper` 컴포넌트에 padding prop을 추가했습니다.
기본값이 16px이여서, 별도로 지정하지 않아도 기존과 동일하게 적용됩니다.

`sm` → 16px (p-4)
`md` → 20px (p-5)
`lg` → 24px (p-6)
`xl` → 28px (p-7)