### PR TITLE
feat: 프로필 수정 API 분리

### DIFF
--- a/src/components/profile/ProfileForm.tsx
+++ b/src/components/profile/ProfileForm.tsx
@@ -7,7 +7,7 @@ import Button from '@/components/ui/Button';
 import GenderSelect from '@/components/ui/GenderSelect';
 import NicknameInput from '@/components/ui/NicknameInput';
 import { genderMap } from '@/constants/gender';
-import { putProfile } from '@/lib/api/member';
+import { putProfile, updateProfile } from '@/lib/api/member';
 import { formatBirthDate } from '@/utils/date';
 import { isValidDay, isValidMonth, isValidYear } from '@/utils/validation';
 import { useRouter } from 'next/navigation';
@@ -41,15 +41,19 @@ export default function ProfileForm({ mode = 'create', initialData }: Props) {
     const birthDate = formatBirthDate(birth.year, birth.month, birth.day);
 
     try {
-      await putProfile({
-        name: nickname,
-        birth: birthDate,
-        gender: genderMap[gender]
-      });
-
       if (mode === 'edit') {
+        await updateProfile({
+          name: nickname,
+          birth: birthDate,
+          gender: genderMap[gender],
+        });
         router.push('/settings');
       } else {
+        await putProfile({
+          name: nickname,
+          birth: birthDate,
+          gender: genderMap[gender],
+        });
         router.push('/');
       }
     } catch (error) {

--- a/src/lib/api/member.ts
+++ b/src/lib/api/member.ts
@@ -42,6 +42,24 @@ export async function getProfile(accessToken: string | undefined) {
 }
 
 
+// 프로필 수정
+export async function updateProfile(payload: {
+  name: string;
+  birth: string;
+  gender: 'MALE' | 'FEMALE';
+}) {
+  const res = await fetch(`${BASE_URL}/api/v1/members/modify/profile`, {
+    method: 'PUT',
+    headers: { 'Content-Type': 'application/json' },
+    credentials: 'include',
+    body: JSON.stringify(payload),
+  });
+
+  if (!res.ok) throw new Error('프로필 수정 실패');
+  return res.json();
+}
+
+
 // 회원 정보 확인
 export async function getMyInfo(accessToken: string | undefined) {
   try {


### PR DESCRIPTION
## 🛰️ Issue Number
<!-- ex) #이슈번호, #이슈번호 -->

## 🪐 작업 내용
<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능) -->

## 📚 Reference
<!-- 참고한 자료나 관련 문서, 링크를 간략히 적어주세요 -->
<img width="805" height="481" alt="image" src="https://github.com/user-attachments/assets/6ae38333-6c96-4a93-a0f8-b32ed9234d14" />
<img width="596" height="628" alt="image" src="https://github.com/user-attachments/assets/2b17625a-e494-4ee5-af68-538818f8f501" />


## ✅ Check List
- [x] 프로필 수정 API 분리

## ℹ️ Note
<!-- 추가적으로 공유할 내용이나 주의사항을 간략히 설명해주세요 -->
기존에는 프로필을 수정할 때도 처음 등록할 때랑 같은 api를 사용했었는데, 그러면 친구코드가 계속 변경이 돼서 수정하는 api 사용하게 분리 및 변경했습니다.